### PR TITLE
Support create JsonRpcProxy

### DIFF
--- a/packages/rpc/src/common/factory/proxy-factory.ts
+++ b/packages/rpc/src/common/factory/proxy-factory.ts
@@ -1,6 +1,5 @@
 import { MessageConnection, ResponseError, Emitter, Event } from 'vscode-jsonrpc';
 import { ApplicationError, Disposable, getPropertyNames, Logger, PipeManager, getTargetClass } from '@malagu/core';
-import { Context } from '@malagu/web/lib/node';
 import { ErrorConverter } from '../converter';
 import { ConnectionHandler } from '../handler';
 
@@ -96,7 +95,7 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
 
     protected async onRequest(method: string, ...args: any[]): Promise<any> {
         const now = Date.now();
-        const message = `${getTargetClass(this.target).name}.${method} with traceId[${Context.getTraceId() || 'none'}]`;
+        const message = `${getTargetClass(this.target).name}.${method}`;
         // eslint-disable-next-line no-unused-expressions
         this.logger?.info(`starting ${message}`);
         try {
@@ -112,7 +111,7 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
             const reason = e.message || '';
             const stack = e.stack || '';
             // eslint-disable-next-line no-unused-expressions
-            this.logger?.error(`Request ${method} failed with error: ${reason} with traceId[${Context.getTraceId() || 'none'}]`, stack);
+            this.logger?.error(`Request ${method} failed with error: ${reason}`, stack);
             throw e;
         } finally {
             // eslint-disable-next-line no-unused-expressions

--- a/packages/rpc/src/common/proxy/delegating-http-proxy-creator.ts
+++ b/packages/rpc/src/common/proxy/delegating-http-proxy-creator.ts
@@ -1,0 +1,68 @@
+import { Component, Autowired, Value, PostConstruct } from '@malagu/core';
+import { RestOperations } from '@malagu/web';
+import { ProxyCreator } from './proxy-protocol';
+import { EndpointResolver } from '../endpoint';
+import { ConnnectionFactory, JsonRpcProxy } from '../factory';
+import { Channel } from '../channal';
+import { ErrorConverter } from '../converter';
+import { AxiosRequestConfig } from 'axios';
+import { ClientConfigProcessor } from '../processor';
+import { HttpProxyCreator } from './http-proxy-creator';
+
+@Component(ProxyCreator)
+export class DelegatingHttpProxyCreator implements ProxyCreator {
+
+    @Autowired(ConnnectionFactory)
+    protected connnectionFactory: ConnnectionFactory<Channel>;
+
+    @Autowired(EndpointResolver)
+    protected endpointResolver: EndpointResolver;
+
+    @Autowired(RestOperations)
+    protected restOperations: RestOperations;
+
+    @Autowired(ClientConfigProcessor)
+    protected clientConfigProcessor: ClientConfigProcessor;
+
+    @Value('malagu.rpc.client.config')
+    protected readonly clientConfig: AxiosRequestConfig;
+
+    @Value('malagu.rpc.merge.maxCount')
+    protected readonly maxCount: number;
+
+    @Value('malagu.rpc.merge.maxLength')
+    protected readonly maxLength: number;
+
+    @Value('malagu.rpc.merge.timerDelay')
+    protected readonly timerDelay: number;
+
+    @Value('malagu.rpc.merge.enabled')
+    protected readonly enabled: boolean;
+
+    protected delegate: ProxyCreator;
+
+    @PostConstruct()
+    protected init() {
+        this.delegate = new HttpProxyCreator({
+            connnectionFactory: this.connnectionFactory,
+            endpointResolver: this.endpointResolver,
+            restOperations: this.restOperations,
+            clientConfigProcessor: this.clientConfigProcessor,
+            clientConfig: this.clientConfig,
+            merge: {
+                maxCount: this.maxCount,
+                maxLength: this.maxLength,
+                timerDelay: this.timerDelay,
+                enabled: this.enabled
+            }
+        });
+    }
+
+    create<T extends object>(path: string, errorConverters?: ErrorConverter[], target?: object | undefined): JsonRpcProxy<T> {
+        return this.delegate.create(path, errorConverters, target);
+    }
+
+    support(path: string): number {
+        return this.delegate.support(path);
+    }
+}

--- a/packages/rpc/src/common/proxy/index.ts
+++ b/packages/rpc/src/common/proxy/index.ts
@@ -1,3 +1,5 @@
 export * from './proxy-provider';
 export * from './proxy-protocol';
 export * from './http-proxy-creator';
+export * from './delegating-http-proxy-creator';
+

--- a/packages/rpc/src/common/utils/rpc-util.ts
+++ b/packages/rpc/src/common/utils/rpc-util.ts
@@ -1,10 +1,39 @@
 import { interfaces } from 'inversify';
 import { ContainerUtil } from '@malagu/core';
 import { ID_KEY, RPC } from '../annotation';
+import { HttpProxyCreator, HttpProxyCreatorOptions, MergeOptions } from '../proxy/http-proxy-creator';
+import urlJoin = require('url-join');
+import { ProxyCreator } from '../proxy/proxy-protocol';
+
+let defaultProxyCreator: ProxyCreator | undefined;
 
 export namespace RpcUtil {
-    export function get<T>(rpcServiceIdentifier: interfaces.ServiceIdentifier<T>): T {
+    export function get<T extends object>(rpcServiceIdentifier: interfaces.ServiceIdentifier<T>): T {
+        if (defaultProxyCreator) {
+            return defaultProxyCreator.create<T>(toPath(rpcServiceIdentifier));
+        }
         return ContainerUtil.getTagged(RPC, ID_KEY, rpcServiceIdentifier);
+    }
+
+    export function getDefaultProxyCreator(endpoint: string, options?: Partial<HttpProxyCreatorOptions<Partial<MergeOptions>>>) {
+        return defaultProxyCreator;
+    }
+
+    export function setDefaultProxyCreator(endpoint: string, options?: Partial<HttpProxyCreatorOptions<Partial<MergeOptions>>>) {
+        defaultProxyCreator = createProxyCreator(endpoint, options);
+    }
+
+    export function createProxyCreator(endpoint: string, options?: Partial<HttpProxyCreatorOptions<Partial<MergeOptions>>>) {
+        return new HttpProxyCreator({ ...options, endpointResolver: {
+            resolve(serviceIdentifier: string) {
+                return Promise.resolve(urlJoin(endpoint, serviceIdentifier));
+            }
+        }});
+    }
+
+    export function create<T extends object>(endpoint: string, rpcServiceIdentifier: interfaces.ServiceIdentifier<T>,
+        options?: Partial<HttpProxyCreatorOptions<Partial<MergeOptions>>>): T {
+        return createProxyCreator(endpoint, options).create<T>(toPath(rpcServiceIdentifier));
     }
 
     export function toPath(serviceIdentifier: any) {


### PR DESCRIPTION
优化 RpcUtil 工具，开发者可以根据 endpoint 和服务标识创建 JSON RPC 代理创建器，通过代理创建器创建代理对象，访问远端 RPC 接口，而不依赖 IoC 容器的构建。使用方式如下：
```typescript
// 配置一个全局默认的代理创建器，大部分情况只需要配置一次
RpcUtil.createDefaultProxyCreator('http://localhost:3000/api', {});

// 业务代码中调用 rpc 接口

const welcomeServer =  RpcUtil.get<WelcomeServer>(WelcomeServer);

// 特殊情况不想使用默认代理创建器
RpcUtil.createProxyCreator('http://localhost:3001/api', {}) // 创建一个新的代理创建器
RpcUtil.create('http://localhost:3001/api', WelcomeServer, {}) // 一步到位，直接创建代理对象
```
