### PR TITLE
feat(vue) Support Jsx Render Vue支持JSX渲染

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -5,9 +5,13 @@
   "main": "lib/browser/index.js",
   "typings": "lib/browser/index.d.ts",
   "dependencies": {
+    "@babel/core": "^7.14.6",
+    "@babel/plugin-transform-modules-commonjs": "^7.14.5",
     "@malagu/core": "1.27.1",
+    "@vue/babel-plugin-jsx": "^1.0.6",
     "@vue/compiler-sfc": "^3.0.11",
     "autoprefixer": "^9.8.6",
+    "babel-loader": "^8.2.2",
     "cache-loader": "^4.1.0",
     "css-minimizer-webpack-plugin": "^3.0.0",
     "cssnano": "^4.1.11",

--- a/packages/vue/src/hooks/webpack.ts
+++ b/packages/vue/src/hooks/webpack.ts
@@ -47,6 +47,25 @@ function createVueRule(webpackConfig: any) {
         .end()
         .end();
 
+    webpackConfig.module
+      .rule('ts')
+        .test(/\.ts$/)
+        .end()
+      .rule('tsx')
+        .test(/\.tsx$/)
+          .use('babel-loader')
+            .loader('babel-loader')
+            .options({
+              plugins: ['@babel/plugin-transform-modules-commonjs', '@vue/babel-plugin-jsx']
+            }).end()
+          .use('ts-loader')
+            .loader('ts-loader')
+            .options({
+              experimentalWatchApi: true,
+              transpileOnly: true,
+              appendTsxSuffixTo: ['\.vue$']
+            }).after('babel-loader');
+
     webpackConfig.plugin('vue-loader')
         .use(require('vue-loader').VueLoaderPlugin);
 }


### PR DESCRIPTION
Vue支持JSX渲染

安装以下package支持JSX

- @babel/core
- @babel/plugin-transform-modules-commonjs
- @vue/babel-plugin-jsx
- babel-loader

修webpack规则如下

- 将原有的ts规则修改为仅适用于.ts文件
- 针对.tsx文件专门配置babel-loader和ts-loader，用以处理JSX标签