### PR TITLE
feat(cloud-plugin): 支持命令行参数输入账号配置信息

### DIFF
--- a/dev-packages/cloud-plugin/package.json
+++ b/dev-packages/cloud-plugin/package.json
@@ -9,13 +9,15 @@
     "dotenv": "^8.2.0",
     "fs-extra": "^8.1.0",
     "inquirer": "^6.5.1",
-    "js-yaml": "^4.0.0"
+    "js-yaml": "^4.0.0",
+    "lodash.merge": "^4.6.2"
   },
   "publishConfig": {
     "access": "public"
   },
   "keywords": [
-    "malagu-component", "malagu-plugin"
+    "malagu-component",
+    "malagu-plugin"
   ],
   "license": "MIT",
   "repository": {
@@ -41,7 +43,8 @@
   },
   "devDependencies": {
     "@malagu/ext-scripts": "1.40.1",
-    "@types/inquirer": "^6.5.0"
+    "@types/inquirer": "^6.5.0",
+    "@types/lodash.merge": "^4.6.6"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/dev-packages/cloud-plugin/src/hooks/cli.ts
+++ b/dev-packages/cloud-plugin/src/hooks/cli.ts
@@ -1,4 +1,5 @@
 import { CliContext } from '@malagu/cli-common';
+import { CmdOptions } from '.';
 import { CloudUtils } from './utils';
 
 export default async (context: CliContext) => {
@@ -6,8 +7,13 @@ export default async (context: CliContext) => {
     program
         .command('config')
         .description('config cloud profile')
-        .action(() => {
+        .option('-u, --account-id [accountId]', 'Account id')
+        .option('-i, --access-key-id [accessKeyId]', 'Access key id')
+        .option('-k, --access-key-secret [accessKeySecret]', 'Access key secret')
+        .option('-t, --token [token]', 'Access token')
+        .option('-r, --region [region]', 'Region of deployment')
+        .action((opts: CmdOptions) => {
             const { regions, profilePath } = CloudUtils.getConfiguration(cfg);
-            CloudUtils.promptForProfile(profilePath, regions);
+            CloudUtils.getProfile(profilePath, regions, opts);
         });
 };

--- a/dev-packages/cloud-plugin/src/hooks/cloud-protocol.ts
+++ b/dev-packages/cloud-plugin/src/hooks/cloud-protocol.ts
@@ -28,3 +28,10 @@ export interface CloudConfiguration {
     [key: string]: any;
 }
 
+export interface CmdOptions {
+    accountId: string;
+    accessKeyId: string;
+    accessKeySecret: string;
+    region: string;
+    token?: string;
+}

--- a/dev-packages/cloud-plugin/src/hooks/utils.ts
+++ b/dev-packages/cloud-plugin/src/hooks/utils.ts
@@ -1,9 +1,10 @@
 import { ensureFile, existsSync, readFile, writeFile } from 'fs-extra';
 import { prompt } from 'inquirer';
 import { resolve, sep } from 'path';
-import { CloudConfiguration, Profile } from './cloud-protocol';
+import { CloudConfiguration, CmdOptions, Profile } from './cloud-protocol';
 import { load, dump } from 'js-yaml';
 import { ApplicationConfig, BACKEND_TARGET, getMalaguConfig, getMalaguHomePath } from '@malagu/cli-common';
+const merge = require('lodash.merge');
 
 export namespace CloudUtils {
 
@@ -27,14 +28,13 @@ export namespace CloudUtils {
         return load(content);
     }
 
-    export async function promptForProfile(profilePath: string, regions: string[]): Promise<Profile> {
+    export async function getProfileFromQuestion(profile: Profile, regions: string[]): Promise<Profile> {
         const mark = (source: string) => {
             if (source) {
                 const subStr = source.slice(-4);
                 return `***********${subStr}`;
             }
         };
-        const profile = await getProfileFromFile(profilePath) || { account: { id: '' }, credentials: { accessKeyId: '', accessKeySecret: '' }, region: '' };
         const markedAccountId = mark(profile.account.id);
         const markedaccessKeyId = mark(profile.credentials.accessKeyId);
         const markedAccessKeySecret = mark(profile.credentials.accessKeySecret);
@@ -66,7 +66,7 @@ export namespace CloudUtils {
             }
         ];
 
-        const { accountId, accessKeyId, accessKeySecret, region  } = await prompt(questions);
+        const { accountId, accessKeyId, accessKeySecret, region } = await prompt(questions);
         if (accountId !== markedAccountId) {
             profile.account.id = accountId;
         }
@@ -79,9 +79,48 @@ export namespace CloudUtils {
 
         profile.region = region;
 
+        return profile;
+    }
+
+    export function getProfileFromCmd(opts: CmdOptions): Profile {
+        const profile: Profile = {
+            account: { id: opts.accountId },
+            credentials: {
+                accessKeyId: opts.accessKeyId,
+                accessKeySecret: opts.accessKeySecret,
+                token: opts.token,
+            },
+            region: opts.region
+        };
+        return profile;
+    }
+
+    export async function saveProfile(profilePath: string, profile: Profile): Promise<void> {
         const path = getProfilePath(profilePath);
         await ensureFile(path);
         await writeFile(path, dump(profile));
+    }
+
+    export async function getProfile(profilePath: string, regions: string[], opts: CmdOptions): Promise<Profile> {
+        const initProfile = { account: { id: '' }, credentials: { accessKeyId: '', accessKeySecret: '' }, region: '' };
+        let profile = await getProfileFromFile(profilePath) || initProfile;
+
+        if (opts.accessKeyId && opts.accessKeySecret) {
+            const cmdProfile = getProfileFromCmd(opts);
+            profile = merge(profile, cmdProfile);
+        } else {
+            profile = await getProfileFromQuestion(profile, regions);
+        }
+
+        await saveProfile(profilePath, profile);
+        return profile;
+    }
+
+    export async function promptForProfile(profilePath: string, regions: string[]): Promise<Profile> {
+        const initProfile = { account: { id: '' }, credentials: { accessKeyId: '', accessKeySecret: '' }, region: '' };
+        let profile = await getProfileFromFile(profilePath) || initProfile;
+        profile = await getProfileFromQuestion(profile, regions);
+        await saveProfile(profilePath, profile);
         return profile;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2825,6 +2825,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.merge@^4.6.6":
+  version "4.6.6"
+  resolved "https://r.cnpmjs.org/@types/lodash.merge/download/@types/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
+  integrity sha1-uEtAPB0xvELVF3LRzVVX+gCM09Y=
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.mergewith@^4.6.6":
   version "4.6.6"
   resolved "https://registry.npm.taobao.org/@types/lodash.mergewith/download/@types/lodash.mergewith-4.6.6.tgz#c4698f5b214a433ff35cb2c75ee6ec7f99d79f10"


### PR DESCRIPTION
```bash  
                 ___
 /'\_/`\          /\_ \
/\      \     __  \//\ \      __       __   __  __
\ \ \__\ \  /'__`\  \ \ \   /'__`\   /'_ `\/\ \/\ \
 \ \ \_/\ \/\ \L\.\_ \_\ \_/\ \L\.\_/\ \L\ \ \ \_\ \
  \ \_\\ \_\ \__/.\_\/\____\ \__/.\_\ \____ \ \____/
   \/_/ \/_/\/__/\/_/\/____/\/__/\/_/\/___L\ \/___/
                                       /\____/
                   @malagu/cli@1.40.1  \_/__/

╭──────────────────────────────────────────────────╮
│      Serverless Frist Development Framework      │
╰──────────────────────────────────────────────────╯

Usage: malagu config [options]

config cloud profile

Options:
  -u, --account-id [accountId]               Account id
  -i, --access-key-id [accessKeyId]          Access key id
  -k, --access-key-secret [accessKeySecret]  Access key secret
  -t, --token [token]                        Access token
  -r, --region [region]                      Region of deployment
  -h, --help                                 display help for command
```
