### PR TITLE
fix(frameworks): fix angular deploy

### DIFF
--- a/dev-packages/frameworks/src/frameworks.ts
+++ b/dev-packages/frameworks/src/frameworks.ts
@@ -68,9 +68,9 @@ export const frameworks = [
         useRuntime: 'default',
         useMode: [ 'static' ],
         settings: {
-            outputDir: 'build',
+            outputDir: 'dist/${pkg.name}',
             frontend: {
-                compileCommand: 'npx ng build --base-href ${frontend.malagu.server.path}'
+                compileCommand: 'npx ng build --base-href ${malagu.server.path}'
             }
         },
         detectors: {


### PR DESCRIPTION
运行 ng new 项目名，生成的项目 package.json 的 name 字段与项目名一致。
默认情况下，输出目录是 dist/项目名/ 。要输出到其它文件夹，就要修改 angular.json 中的 outputPath。
具体文档在：https://angular.cn/guide/deployment