### PR TITLE
修复了一些错误

### DIFF
--- a/plugins/node-plugin/src/hooks/build.ts
+++ b/plugins/node-plugin/src/hooks/build.ts
@@ -3,15 +3,17 @@ import { join } from 'path';
 import { renameSync, writeFileSync, existsSync } from 'fs-extra';
 
 const entryContent =  `
-process.env.SERVER_PATH = {{ path }};
-process.env.SERVER_PORT = {{ port }};
+const path = '{{ path }}';
+const port = {{ port }};
+process.env.SERVER_PATH = path;
+process.env.SERVER_PORT = port;
 const app = require('./_index');
 let target = app;
 if (typeof app === 'object' && app.default) {
     target = app.default;
 }
 if (target && typeof target.listen === 'function') {
-    const server = target.listen({{ port }});
+    const server = target.listen(port);
     if (typeof server === 'object') {
         server.timeout = 0;
         server.keepAliveTimeout = 0;
@@ -20,7 +22,7 @@ if (target && typeof target.listen === 'function') {
 }
 
 if (typeof target === 'function') {
-    target(PORT);
+    target(port);
 }
 `;
 
@@ -28,8 +30,8 @@ export default async (context: BuildContext) => {
     const { cfg } = context;
     const outputPath = PathUtil.getBackendProjectDistPath();
     const server = ConfigUtil.getBackendMalaguConfig(cfg).server;
-    const port = server?.port || 9000;
-    const path = server?.path;
+    const port = server?.port ?? 9000;
+    const path = server?.path ?? '';
     const oldIndexPath = join(outputPath, 'index.js');
     const newIndexPath = join(outputPath, '_index.js');
     if (existsSync(oldIndexPath)) {


### PR DESCRIPTION
1. fix(node-plugin): 修复当 server.path 不为空时， 构建产物异常导致项目启动报错的问题
如果用户配置了 server.path 时，应该在模版里 server.path 的值加引号，否者语法错误运行出错
