### PR TITLE
fix(scf-plugin): 修复腾讯云绑定自定义域名报错的问题

### DIFF
--- a/plugins/scf-plugin/malagu-api-gateway-common.yml
+++ b/plugins/scf-plugin/malagu-api-gateway-common.yml
@@ -28,7 +28,7 @@ malagu:
         # certificateId: xxxx
         protocol: http
         netType: OUTER
-        isDefaultMapping: true
+        isDefaultMapping: false
         pathMapping:
           path: /
           environment: ${malagu.cloud.apiGateway.release.environmentName}

--- a/plugins/scf-plugin/src/hooks/deploy.ts
+++ b/plugins/scf-plugin/src/hooks/deploy.ts
@@ -513,6 +513,7 @@ function parseCustomDomainMeta(req: any, customDomainMeta: any, serviceId: strin
     const { pathMapping } = customDomainMeta;
 
     if (pathMapping) {
+        req.IsDefaultMapping = false;
         req.PathMappingSet = [{
             Path: pathMapping.path,
             Environment: pathMapping.environment


### PR DESCRIPTION
腾讯云绑定自定义域名时报错：“自定义路径与默认路径冲突”，原因是当需要自定义映射路径时需要将 `IsDefaultMapping` 设置为 `fasle`