### PR TITLE
frameworks 增加框架支持及优化

### DIFF
--- a/dev-packages/frameworks/src/frameworks.ts
+++ b/dev-packages/frameworks/src/frameworks.ts
@@ -122,7 +122,7 @@ export const frameworks = [
         useMode: [ 'static' ],
         settings: {
             outputDir: 'dist',
-            compileCommand: 'npx ember-cli build --environment=production'
+            compileCommand: 'npx ember build --environment=production'
         },
         detectors: {
             every: [

--- a/dev-packages/frameworks/src/frameworks.ts
+++ b/dev-packages/frameworks/src/frameworks.ts
@@ -266,6 +266,20 @@ export const frameworks = [
         }
     },
     {
+        name: 'fastify',
+        useRuntime: 'default',
+        useMode: [ 'node' ],
+        settings: {},
+        detectors: {
+            every: [
+                {
+                    path: 'package.json',
+                    matchContent: '"dependencies":\\s*{[^}]*"fastify":\\s*".+?"[^}]*}',
+                }
+            ]
+        }
+    },
+    {
         name: 'nest',
         useRuntime: 'default',
         useMode: ['node', 'unpackage'],

--- a/plugins/node-plugin/package.json
+++ b/plugins/node-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "dependencies": {
     "@malagu/cli-common": "2.8.3",
-    "@vendia/serverless-express": "^4.5.2"
+    "@vendia/serverless-express": "^4.5.2",
+    "aws-lambda-fastify": "^2.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/node-plugin/src/entry.ts
+++ b/plugins/node-plugin/src/entry.ts
@@ -7,16 +7,29 @@ let target = app;
 if (typeof app === 'object' && app.default) {
     target = app.default;
 }
-if (target && typeof target.listen === 'function') {
-    try {
-        const server = target.listen(port);
-        if (typeof server === 'object') {
-            server.timeout = 0;
-            server.keepAliveTimeout = 0;
+(async () => {
+    if (target && typeof target.listen === 'function') {
+        try {
+            let server;
+            if (target.server) {
+                // view fastify issue: https://github.com/fastify/fastify/issues/1022
+                server = target.server;
+                // fastify listen function not return HTTP server instance, return the listening address
+                await target.listen(port, '0.0.0.0');
+            } else {
+                // view doc: https://cloud.tencent.com/document/product/583/56124
+                server = target.listen(port, '0.0.0.0');
+            }
+            server = target.listen(port);
+            if (typeof server === 'object') {
+                server.timeout = 0;
+                server.keepAliveTimeout = 0;
+            }
+        } catch (error) {
+            // NoOp
         }
-    } catch (error) {
-        // NoOp
+    } else if (typeof target === 'function') {
+        target(port);
     }
-} else if (typeof target === 'function') {
-    target(port);
-}
+})();
+

--- a/plugins/node-plugin/src/hooks/props.ts
+++ b/plugins/node-plugin/src/hooks/props.ts
@@ -45,7 +45,8 @@ export default async (context: PropsContext) => {
             props.entry = renderEntry(entryTemplate, cfg, props.entry);
         } else if (CommandUtil.includesCommand(context.args, [ 'build', 'deploy' ])) {
             const isLambda = pkg.componentPackages.some(c => c.name === '@malagu/lambda-plugin');
-            const entryTemplate = join(__dirname, '..', isLambda ? 'lambda-entry.js' : 'entry.js');
+            const isFastify = pkg.framework?.name === 'fastify';
+            const entryTemplate = join(__dirname, '..', isLambda ? (isFastify ? 'lambda-fastify-entry.js' :'lambda-entry.js') : 'entry.js');
             props.entry = renderEntry(entryTemplate, cfg, props.entry);
         } else {
             props.entry = join(PathUtil.getProjectHomePath(), 'entry.js');

--- a/plugins/node-plugin/src/lambda-fastify-entry.ts
+++ b/plugins/node-plugin/src/lambda-fastify-entry.ts
@@ -1,0 +1,11 @@
+const path = '{{ path }}';
+const port = parseInt('{{ port }}');
+process.env.SERVER_PATH = path;
+process.env.SERVER_PORT = port + '';
+const awsLambdaFastify = require('aws-lambda-fastify');
+const appPromise = require('{{ entry }}');
+
+export const handler = async (event: any, context: any, callback: any) => {
+  const app = await appPromise;
+  return awsLambdaFastify(app)(event, context, callback);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4151,6 +4151,11 @@ autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
+aws-lambda-fastify@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/aws-lambda-fastify/-/aws-lambda-fastify-2.0.2.tgz#e2a10d58d2b35f67c6831e4f2b2dd3998f05bd10"
+  integrity sha512-fq2jd2bVL2YUhyoL7FgXFAjn+uZv82i205r206PIGq/1/I7DxDsSWyuL+JxwkFKl1TfGWMppOJxqPjwXTQyCzw==
+
 aws-sdk@^2.807.0:
   version "2.896.0"
   resolved "https://registry.nlark.com/aws-sdk/download/aws-sdk-2.896.0.tgz?cache=0&sync_timestamp=1619722810046&other_urls=https%3A%2F%2Fregistry.nlark.com%2Faws-sdk%2Fdownload%2Faws-sdk-2.896.0.tgz#5328ef20000bd7d02ea03f3b7f96dba175946142"
@@ -9306,7 +9311,7 @@ koa-convert@^2.0.0:
     co "^4.6.0"
     koa-compose "^4.1.0"
 
-koa@^2.13.3, koa@^2.13.4:
+koa@^2.13.0, koa@^2.13.3, koa@^2.13.4:
   version "2.13.4"
   resolved "https://registry.yarnpkg.com/koa/-/koa-2.13.4.tgz#ee5b0cb39e0b8069c38d115139c774833d32462e"
   integrity sha512-43zkIKubNbnrULWlHdN5h1g3SEKXOEzoAlRsHOTFpnlDu8JlAOZSMJBLULusuXRequboiwJcj5vtYXKB3k7+2g==


### PR DESCRIPTION
1. `ember` 的 `compileCommand` 从 `npx ember-cli` 修改为 `npx ember`
2.  增加 `fastify` 框架的支持。`fastify` 的 `listen` 需指定 host 为 `0.0.0.0`， 否者默认为 `localhost`, 这与 `httpServer.listen` 不同，`fastify` 做了特殊处理。